### PR TITLE
Fix todo demo AR type coercion

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -4,7 +4,7 @@ class TodosController < ApplicationController
 
   def show
     session[:todo_filter] = "all" unless filter_permitted?(session[:todo_filter])
-    @all_todos = Todo.where(session_id: session.id)
+    @all_todos = Todo.where(session_id: session.id.to_s)
     @filtered_todos = @all_todos.public_send(session[:todo_filter]).order(:created_at)
   end
 


### PR DESCRIPTION
AR raises `TypeError: can't quote Rack::Session::SessionId` if `session.id` is not explicitly casted to string