### PR TITLE
Normalize emails when sending to Gravatar

### DIFF
--- a/app/reflexes/gravatar_reflex.rb
+++ b/app/reflexes/gravatar_reflex.rb
@@ -4,7 +4,7 @@ class GravatarReflex < ApplicationReflex
   def perform
     email = element[:value]
     return unless %r{[^@]+@[^\.]+\..+}.match?(email)
-    email_md5 = Digest::MD5.hexdigest(email)
+    email_md5 = Digest::MD5.hexdigest(email.downcase.strip)
     @gravatar_image_url = "https://www.gravatar.com/avatar/#{email_md5}"
   end
 end


### PR DESCRIPTION
[Gravatar](https://en.gravatar.com/site/implement/hash/) requires email hashes to be produced by a consistent method that involves removing whitespace and forcing to lower-case. Apply these rules in `GravatarReflex` so that users will get expected results even if they normally write their email including upper-case characters.