### PR TITLE
Fix tabular pagination bug

### DIFF
--- a/app/controllers/tabulars_controller.rb
+++ b/app/controllers/tabulars_controller.rb
@@ -11,9 +11,7 @@ class TabularsController < ApplicationController
 
     restaurants = Restaurant.order(@order_by => @direction)
     restaurants = restaurants.search(@query) if @query.present?
-    pages = (restaurants.count / Pagy::VARS[:items].to_f).ceil
 
-    @page = 1 if @page > pages
     @pagy, @restaurants = pagy(restaurants, page: @page)
   end
 

--- a/app/helpers/tabulars_helper.rb
+++ b/app/helpers/tabulars_helper.rb
@@ -20,4 +20,12 @@ module TabularsHelper
   def pagy_get_params(params)
     params.merge query: @query, order_by: @order_by, direction: @direction
   end
+
+  def prev_page
+    @pagy.prev || 1
+  end
+
+  def next_page
+    @pagy.next || @pagy.last
+  end
 end

--- a/app/views/tabulars/_paginator.html.erb
+++ b/app/views/tabulars/_paginator.html.erb
@@ -1,6 +1,6 @@
 <nav>
   <ul class="pagination">
-    <li class="page-item"><a href="#" class="page-link" data-reflex="click->TabularReflex#paginate" data-page="<%= @pagy.prev %>">←</a></li>
+    <li class="page-item"><a href="#" class="page-link" data-reflex="click->TabularReflex#paginate" data-page="<%= prev_page %>">←</a></li>
     <% @pagy.series.each do |item| %>
       <% if item == :gap %>
         <li class="page-item disabled"><a class="page-link">...</a></li>
@@ -10,6 +10,6 @@
         </li>
       <% end %>
     <% end %>
-    <li class="page-item"><a href="#" class="page-link" data-reflex="click->TabularReflex#paginate" data-page="<%= @pagy.next %>">→</a></li>
+    <li class="page-item"><a href="#" class="page-link" data-reflex="click->TabularReflex#paginate" data-page="<%= next_page %>">→</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
When user is on first page, and clicks the left pagination arrow, the
data-page attribute gets set to null, and throws an error.

Similar error occurs when user in on last page, and click the right pagination.

![image](https://user-images.githubusercontent.com/1905793/82155285-ce520780-9841-11ea-8a72-8a06d53afad1.png)
