### PR TITLE
uses auto serialization of form

### DIFF
--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
 class ValidationsController < ApplicationController
-  before_action :assign_params
-
   def show
     @user ||= User.new(user_params)
     @user.validate
   end
 
   private
-
-  def assign_params
-    self.params = @reflex_params if @reflex_params.present?
-  end
 
   def user_params
     return {} unless params.key?(:user)

--- a/app/javascript/controllers/validations_controller.js
+++ b/app/javascript/controllers/validations_controller.js
@@ -3,15 +3,13 @@ import { debounce } from 'lodash-es'
 import ApplicationController from './application_controller'
 
 export default class extends ApplicationController {
-  static targets = ['firstName', 'lastName', 'email', 'submit']
-
   connect () {
     super.connect()
     this.perform = debounce(this._perform, 250)
   }
 
   _perform (event) {
-    this.stimulate('ValidationsReflex#perform', this.userParams)
+    this.stimulate('ValidationsReflex#perform')
   }
 
   reset (event) {
@@ -21,15 +19,5 @@ export default class extends ApplicationController {
 
   validate (event) {
     this.perform()
-  }
-
-  get userParams () {
-    return {
-      user: {
-        first_name: this.firstNameTarget.value,
-        last_name: this.lastNameTarget.value,
-        email: this.emailTarget.value
-      }
-    }
   }
 }

--- a/app/reflexes/validations_reflex.rb
+++ b/app/reflexes/validations_reflex.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ValidationsReflex < ApplicationReflex
-  def perform(params = {})
-    @reflex_params = params
+  def perform
+    params
   end
 end


### PR DESCRIPTION
Thanks to https://github.com/hopsoft/stimulus_reflex/issues/199 we can now use magic form parameters and simplify this expo example.

Interestingly you have to call `params` in your reflex, or the params will not be available to the `Validationscontroller` see https://github.com/hopsoft/stimulus_reflex_expo/compare/master...RolandStuder:form_using_params?expand=1#diff-1adfcc167ad3f17d87f671757d65bccbL5