### PR TITLE
developer happiness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :development, :test do
 end
 
 group :development do
-  gem "annotate"
+# gem "annotate"
   gem "listen", ">= 3.0.5", "< 3.2"
   gem "model_probe"
   # gem "spring"
@@ -49,4 +49,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,9 +58,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    annotate (3.1.1)
-      activerecord (>= 3.2, < 7.0)
-      rake (>= 10.4, < 14.0)
     ast (2.4.0)
     awesome_print (1.8.0)
     bindex (0.8.1)
@@ -287,7 +284,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  annotate
   awesome_print
   bootsnap (>= 1.4)
   byebug
@@ -314,7 +310,6 @@ DEPENDENCIES
   standard
   stimulus_reflex (= 3.2.2)
   tmuxinator
-  tzinfo-data
   valid_email (~> 0.1)
   web-console (>= 3.3.0)
   webdrivers


### PR DESCRIPTION
I have discovered and want to use the [hookup](https://github.com/tpope/hookup) gem to manage migrations across diverging branches during iteration.

The annotate gem can be run manually if desired but its behavior will conflict with hookup as the annotate makes the model file change - creating a diff in the model as soon as the migration is run.

I also commented out the `tzinfo-data` gem as I just don't think that we have a lot of Windows Ruby devs (not using WSL2) that are working on timezone differences.