### PR TITLE
use params instead of sessions for permalinks demo

### DIFF
--- a/app/controllers/permalinks_controller.rb
+++ b/app/controllers/permalinks_controller.rb
@@ -3,13 +3,6 @@
 class PermalinksController < ApplicationController
   def show
     @categories = Restaurant.select(:category).distinct.order(:category).map(&:category)
-
-    unless @stimulus_reflex
-      session[:category] = params[:category] || ""
-      session[:rating] = params[:rating] || ""
-      session[:price] = params[:price] || ""
-    end
-
-    @restaurants = Restaurant.category(session[:category]).stars(session[:rating]).price(session[:price])
+    @restaurants = Restaurant.category(params[:category]).stars(params[:rating]).price(params[:price])
   end
 end

--- a/app/reflexes/permalink_reflex.rb
+++ b/app/reflexes/permalink_reflex.rb
@@ -2,6 +2,6 @@
 
 class PermalinkReflex < ApplicationReflex
   def filter
-    session[element[:name].to_sym] = element.value
+    params[element[:name].to_sym] = element.value
   end
 end

--- a/app/views/permalinks/_demo.html.erb
+++ b/app/views/permalinks/_demo.html.erb
@@ -1,4 +1,4 @@
-<div class="form-row mb-4" data-controller="permalink" data-permalink-category="<%= session[:category] %>" data-permalink-rating="<%= session[:rating] %>" data-permalink-price="<%= session[:price] %>">
+<div class="form-row mb-4" data-controller="permalink" data-permalink-category="<%= params[:category] %>" data-permalink-rating="<%= params[:rating] %>" data-permalink-price="<%= params[:price] %>">
   <div class="col-3 offset-3">
     <%= label_tag "rating" %>
     <%= select_tag "rating",

--- a/app/views/permalinks/_demo.html.erb
+++ b/app/views/permalinks/_demo.html.erb
@@ -2,7 +2,7 @@
   <div class="col-3 offset-3">
     <%= label_tag "rating" %>
     <%= select_tag "rating",
-            options_for_select((1..5), session[:rating]),
+            options_for_select((1..5), params[:rating]),
             include_blank: true,
             class: "form-control",
             data: { action: "change->permalink#filter",
@@ -11,7 +11,7 @@
   <div class="col-3">
     <%= label_tag "category" %>
     <%= select_tag "category",
-            options_for_select(@categories, session[:category]),
+            options_for_select(@categories, params[:category]),
             include_blank: true,
             class: "form-control",
             data: { action: "change->permalink#filter",
@@ -21,8 +21,8 @@
     <%= label_tag "price", "Price", class: "d-block" %>
     <div class="btn-group btn-group-toggle" id="price-button-group">
       <% {'$' => 1, '$$' => 2, '$$$' => 3}.each do |key, value| %>
-        <%= label_tag '', class: "btn btn-outline-primary hover_white #{'active' if session[:price]&.include?(value.to_s)}" do %>
-          <%= check_box_tag 'price', value, session[:price]&.include?(value.to_s), id: "price-#{value}", class: "", data: { action: "click->permalink#filter",
+        <%= label_tag '', class: "btn btn-outline-primary hover_white #{'active' if params[:price]&.include?(value.to_s)}" do %>
+          <%= check_box_tag 'price', value, params[:price]&.include?(value.to_s), id: "price-#{value}", class: "", data: { action: "click->permalink#filter",
                                                                   reflex_root: "#search-results,#price-button-group"} %>
           <%= key %>
         <% end %>


### PR DESCRIPTION
Using sessions for the permalinks demo is unnecessary now that we have params. Also the current implementation is buggy, where selecting a rating then a category and then a rating again, does not show the correct results.