### PR TITLE
Scope page morph on chat demo, allow submit via enter keydown, prevent empty submission

### DIFF
--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -17,6 +17,8 @@ export default class extends ApplicationController {
   }
 
   post (event) {
+    if (this.inputTarget.value === '') { return }
+
     Rails.stopEverything(event)
     lastMessageId = Math.random()
     this.stimulate(
@@ -27,7 +29,19 @@ export default class extends ApplicationController {
     )
   }
 
+  postOnEnterKeydown(event) {
+    if (event.code === 'Enter') {
+      event.preventDefault();
+      this.post(event);
+      this.clearMessages();
+    }
+  }
+
   afterPost () {
+    this.clearMessages();
+  }
+
+  clearMessages() {
     this.inputTarget.value = ''
     this.inputTarget.focus()
     this.scroll(1)

--- a/app/views/chats/_color.html.erb
+++ b/app/views/chats/_color.html.erb
@@ -1,7 +1,8 @@
 <div id="<%= color %>" data-color="<%= color %>"
   data-controller="chat" data-action="chats:added@document->chat#reload cable-ready:after-morph@document->chat#scroll"
+  data-reflex-root="<%= "##{color}-chat, ##{color}-chat-box" %>"
   class="<%= css "tab-pane bg-white p-4 border border-top-0", "show active": active_chat?(color) %>">
-  <div data-target="chat.list" class="bg-light border rounded mb-2 p-3" style="height:400px; max-width:800px; overflow-y:scroll;">
+  <div id=<%= "#{color}-chat-box" %> data-target="chat.list" class="bg-light border rounded mb-2 p-3" style="height:400px; max-width:800px; overflow-y:scroll;">
     <% @chats.select { |chat| chat[:color] == color }.each do |chat| %>
       <% if chat_author? chat %>
         <div class="<%= chat_css color %> rounded-lg border my-2 p-1 px-2 text-right w-75 float-right">
@@ -16,9 +17,9 @@
       <% end %>
     <% end %>
   </div>
-  <form style="max-width:800px;">
+  <form id="<%= "#{color}-chat" %>"style="max-width:800px;">
     <div class="form-group">
-      <textarea data-target="chat.input" class="form-control border <%= chat_border_css color %>" rows="3" placeholder="Type your message..."></textarea>
+      <textarea data-target="chat.input" data-action="keydown->chat#postOnEnterKeydown" class="form-control border <%= chat_border_css color %>" rows="3" placeholder="Type your message..."></textarea>
     </div>
     <button data-action="click->chat#post" type="submit" class="btn btn-primary btn-lg">Submit</button>
   </form>


### PR DESCRIPTION
This PR attempts to make the chat demo more performant or responsive. It does it by utilizing the [Scoping Page Morphs](https://docs.stimulusreflex.com/morph-modes#scoping-page-morphs)

In addition to that, I've made these changes to improve the UI of the chat demo
- Prevent submitting empty strings
- Enable submitting using the enter key

