### PR TITLE
chore: add validations helper method to gists to register

### DIFF
--- a/app/views/validations/show.html.erb
+++ b/app/views/validations/show.html.erb
@@ -17,4 +17,5 @@
   "app/models/user.rb",
   "app/controllers/validations_controller.rb",
   "app/reflexes/validations_reflex.rb",
+  "app/helpers/validations_helper.rb"
 ) %>


### PR DESCRIPTION
The helper method was not added to the gists that were being rendered to expo, making the example incomplete. 